### PR TITLE
Added ability to get and set Browser Cache TTL settings in zone.

### DIFF
--- a/CloudFlare.Client.Test/Serialization/BrowserCacheTTLSettingTest.cs
+++ b/CloudFlare.Client.Test/Serialization/BrowserCacheTTLSettingTest.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CloudFlare.Client.Api.Zones;
+using CloudFlare.Client.Test.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace CloudFlare.Client.Test.Serialization
+{
+    public class BrowserCacheTTLSettingTest
+    {
+        [Fact]
+        public void TestSerialization()
+        {
+            var sut = new BrowserCacheTTLSetting();
+
+            JsonHelper.GetSerializedKeys(sut).Should().BeEquivalentTo(new SortedSet<string> { "id", "value", "editable", "modified_on" });
+        }
+    }
+}

--- a/CloudFlare.Client.Test/TestData/ZoneSettingsTestData.cs
+++ b/CloudFlare.Client.Test/TestData/ZoneSettingsTestData.cs
@@ -28,5 +28,23 @@ namespace CloudFlare.Client.Test.TestData
                 Js = FeatureStatus.On
             }
         };
+
+        public static List<BrowserCacheTTLSetting> BrowserCacheTTLSettings { get; set; } = new()
+        {
+            new BrowserCacheTTLSetting
+            {
+                Id = "browser_cache_ttl",
+                Value = 0,
+                Editable = true,
+                ModifiedOn = DateTime.Now,
+            },
+            new BrowserCacheTTLSetting
+            {
+                Id = "browser_cache_ttl",
+                Value = 30,
+                Editable = true,
+                ModifiedOn = DateTime.UtcNow,
+            }
+        };
     }
 }

--- a/CloudFlare.Client.Test/Zones/ZoneSettingsUnitTests.cs
+++ b/CloudFlare.Client.Test/Zones/ZoneSettingsUnitTests.cs
@@ -99,5 +99,42 @@ namespace CloudFlare.Client.Test.Zones
 
             alwaysUseHttpsUnderTest.Result.Should().BeEquivalentTo(minify);
         }
+
+        [Fact]
+        public async Task TestUpdateBrowserCacheTTLSettingAsync()
+        {
+            var zone = ZoneTestData.Zones.First();
+            var bcTTL = ZoneSettingsTestData.BrowserCacheTTLSettings.First().Value;
+            var bcTTLUpdateResult = ZoneSettingsTestData.BrowserCacheTTLSettings.Last();
+
+            _wireMockServer
+                .Given(Request.Create().WithPath($"/{ZoneEndpoints.Base}/{zone.Id}/{ZoneSettingsEndpoints.BrowserCacheTTL}").UsingPatch())
+                .RespondWith(Response.Create().WithStatusCode(200)
+                    .WithBody(WireMockResponseHelper.CreateTestResponse(bcTTLUpdateResult)));
+
+            using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
+
+            var alwaysUseHttpsUnderTest = await client.Zones.ZoneSettings.UpdateBrowserCacheTTLSettingAsync(zone.Id, bcTTL);
+
+            alwaysUseHttpsUnderTest.Result.Should().BeEquivalentTo(bcTTLUpdateResult);
+        }
+
+        [Fact]
+        public async Task TestGetBrowserCacheTTLSettingAsync()
+        {
+            var zone = ZoneTestData.Zones.First();
+            var bcTTL = ZoneSettingsTestData.BrowserCacheTTLSettings.First();
+
+            _wireMockServer
+                .Given(Request.Create().WithPath($"/{ZoneEndpoints.Base}/{zone.Id}/{ZoneSettingsEndpoints.BrowserCacheTTL}").UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(200)
+                    .WithBody(WireMockResponseHelper.CreateTestResponse(bcTTL)));
+
+            using var client = new CloudFlareClient(WireMockConnection.ApiKeyAuthentication, _connectionInfo);
+
+            var alwaysUseHttpsUnderTest = await client.Zones.ZoneSettings.GetBrowserCacheTTLSettingAsync(zone.Id);
+
+            alwaysUseHttpsUnderTest.Result.Should().BeEquivalentTo(bcTTL);
+        }
     }
 }

--- a/CloudFlare.Client/Api/Parameters/Endpoints/ZoneSettingsEndpoints.cs
+++ b/CloudFlare.Client/Api/Parameters/Endpoints/ZoneSettingsEndpoints.cs
@@ -8,5 +8,6 @@ namespace CloudFlare.Client.Api.Parameters.Endpoints
     {
         public const string AlwaysUseHttps = "settings/always_use_https";
         public const string Minify = "settings/minify";
+        public const string BrowserCacheTTL = "settings/browser_cache_ttl";
     }
 }

--- a/CloudFlare.Client/Api/Zones/BrowserCacheTTLSetting.cs
+++ b/CloudFlare.Client/Api/Zones/BrowserCacheTTLSetting.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace CloudFlare.Client.Api.Zones
+{
+    /// <summary>
+    /// Browser Cache TTL Settings
+    /// </summary>
+    public class BrowserCacheTTLSetting
+    {
+        /// <summary>
+        /// Id for Browser Cache TTL Setting
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Value of Browser Cache TTL. default value: 14400. Valid values: 0, 30, 60, 120, 300, 1200,
+        /// 1800, 3600, 7200, 10800, 14400, 18000, 28800, 43200, 57600, 72000, 86400, 172800, 259200,
+        /// 345600, 432000, 691200, 1382400, 2073600, 2678400, 5356800, 16070400, 31536000
+        /// </summary>
+        /// <remarks>Setting a TTL of 0 is equivalent to selecting `Respect Existing Headers`</remarks>
+        [JsonProperty("value")]
+        public int Value { get; set; }
+
+        /// <summary>
+        /// Determines if UI allows for editing
+        /// </summary>
+        [JsonProperty("editable")]
+        public bool Editable { get; set; }
+
+        /// <summary>
+        /// Date of last modification
+        /// </summary>
+        [JsonProperty("modified_on")]
+        public DateTime? ModifiedOn { get; set; }
+    }
+}

--- a/CloudFlare.Client/Client/Zones/IZoneSettings.cs
+++ b/CloudFlare.Client/Client/Zones/IZoneSettings.cs
@@ -44,5 +44,25 @@ namespace CloudFlare.Client.Client.Zones
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The new minification setting</returns>
         Task<CloudFlareResult<MinifySetting>> UpdateMinifySettingAsync(string zoneId, MinifySetting setting, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves the <see cref="BrowserCacheTTLSetting"/> related to <see cref="Zone"/> within the Caching/Configuration
+        /// </summary>
+        /// <param name="zoneId">Zone identifier</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Browser Cache TTL settings</returns>
+        Task<CloudFlareResult<BrowserCacheTTLSetting>> GetBrowserCacheTTLSettingAsync(string zoneId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sets the <see cref="BrowserCacheTTLSetting"/> related to the <see cref="Zone"/> within the Caching/Configuration
+        /// </summary>
+        /// <param name="zoneId">Zone identifier</param>
+        /// <param name="value">Value of Browser Cache TTL. default value: 14400. Valid values: 0, 30, 60, 120, 300, 1200,
+        /// 1800, 3600, 7200, 10800, 14400, 18000, 28800, 43200, 57600, 72000, 86400, 172800, 259200,
+        /// 345600, 432000, 691200, 1382400, 2073600, 2678400, 5356800, 16070400, 31536000</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The new Browser Cache TTL settings</returns>
+        /// <remarks>Setting a TTL of 0 is equivalent to selecting `Respect Existing Headers`</remarks>
+        Task<CloudFlareResult<BrowserCacheTTLSetting>> UpdateBrowserCacheTTLSettingAsync(string zoneId, int value, CancellationToken cancellationToken = default);
     }
 }

--- a/CloudFlare.Client/Client/Zones/ZoneSettings.cs
+++ b/CloudFlare.Client/Client/Zones/ZoneSettings.cs
@@ -50,5 +50,19 @@ namespace CloudFlare.Client.Client.Zones
             var requestUri = $"{ZoneEndpoints.Base}/{zoneId}/{ZoneSettingsEndpoints.Minify}";
             return await Connection.PatchAsync<MinifySetting>(requestUri, setting, cancellationToken).ConfigureAwait(false);
         }
+
+        /// <inheritdoc />
+        public async Task<CloudFlareResult<BrowserCacheTTLSetting>> GetBrowserCacheTTLSettingAsync(string zoneId, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"{ZoneEndpoints.Base}/{zoneId}/{ZoneSettingsEndpoints.BrowserCacheTTL}";
+            return await Connection.GetAsync<BrowserCacheTTLSetting>(requestUri, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CloudFlareResult<BrowserCacheTTLSetting>> UpdateBrowserCacheTTLSettingAsync(string zoneId, int value, CancellationToken cancellationToken = default)
+        {
+            var requestUri = $"{ZoneEndpoints.Base}/{zoneId}/{ZoneSettingsEndpoints.BrowserCacheTTL}";
+            return await Connection.PatchAsync<BrowserCacheTTLSetting, int>(requestUri, value, cancellationToken).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Added ability to [get ](https://api.cloudflare.com/#zone-settings-get-browser-cache-ttl-setting)and [set ](https://api.cloudflare.com/#zone-settings-change-browser-cache-ttl-setting)Browser Cache TTL settings in zone.